### PR TITLE
Add procedure to configure autoscaling nodes

### DIFF
--- a/assemblies/rosa-autoscale-nodes.adoc
+++ b/assemblies/rosa-autoscale-nodes.adoc
@@ -1,0 +1,9 @@
+include::_attributes/attributes-openshift-dedicated.adoc[]
+[id="rosa-autoscaling-nodes"]
+= Autoscaling nodes on a cluster
+:context: autoscaling-nodes
+
+[role="_abstract"]
+Autoscale worker nodes in a cluster to increase or decrease the number of resources available.
+
+include::modules/rosa-autoscaling-nodes.adoc[leveloffset=+1]

--- a/modules/rosa-autoscaling-nodes.adoc
+++ b/modules/rosa-autoscaling-nodes.adoc
@@ -1,0 +1,49 @@
+:_module-type: PROCEDURE
+//Specify the _module-type as either "CONCEPT, PROCEDURE, or REFERENCE"
+
+// Module included in the following assemblies:
+//
+// rosa-nodes/rosa-autoscale-nodes.adoc
+
+[id="rosa-autoscaling_{context}"]
+= Autoscaling nodes in a cluster
+
+[role="_abstract"]
+Configure autoscaling to dynamically scale the number of worker nodes up or down based on load. Autoscaling for worker nodes is configured in the machine pool definition.
+
+Successful autoscaling is dependent on having the correct AWS resource quotas in your AWS account. Verify resource quotas and request quota increases from the link:https://aws.amazon.com/console/[AWS console].
+
+.Procedure
+
+. To identify the machine pool IDs in a cluster, enter the following command:
++
+[source,terminal]
+----
+$ rosa list machinepools --cluster=<cluster_name>
+----
++
+.Example output
++
+[source,terminal]
+----
+ID        AUTOSCALING   REPLICAS    INSTANCE TYPE  LABELS    TINTS   AVAILABILITY ZONES
+mp1       No            2           m5.xlarge                        us-east-1a
+----
++
+Decide which machine pool ID you want to configure for autoscaling.
+
+. To enable autoscaling on a machine pool, enter the following command:
++
+[source,terminal]
+----
+$ rosa edit machinepool --cluster=<cluster_name> <machinepool_ID> --enable-autoscaling --min-replicas=<number> --max-replicas=<number>
+----
++
+.Example
++
+Enable autoscaling on a machine pool with the ID `mp1` on a cluster named `mycluster`, with the number of replicas set to scale between 2 and 5 worker nodes:
++
+[source,terminal]
+----
+$ rosa edit machinepool --cluster=mycluster mp1 --enable-autoscaling --min-replicas=2 --max-replicas=5
+----

--- a/modules/rosa-edit-objects.adoc
+++ b/modules/rosa-edit-objects.adoc
@@ -146,7 +146,7 @@ Allows edits to the machine pool in a cluster.
 .Syntax
 [source,terminal]
 ----
-$ rosa edit machinepool --replicas=<number> --name=<machinepool_name> [arguments]
+$ rosa edit machinepool --cluster=<cluster_name> <machinepool_ID> [arguments]
 ----
 
 .Arguments
@@ -155,19 +155,19 @@ $ rosa edit machinepool --replicas=<number> --name=<machinepool_name> [arguments
 |Option |Definition
 
 |--cluster
-|Required: The name or ID (string) of the cluster to edit to which the additional machine pool will be added.
+|Required: The name or ID (string) of the cluster to edit on which the additional machine pool will be edited.
 
 --enable-autoscaling
-|Enable autoscaling of compute nodes. By default, autoscaling is set to `2` nodes. To set non-default node limits, use this argument with the `--min-replicas` and `--max-replicas` arguments.
+|Enable autoscaling of compute nodes. Use this argument with the `--min-replicas` and `--max-replicas` arguments.
 
 |--max-replicas
-|Specifies the maximum number of compute nodes when enabling autoscaling. Default: `2`
+|Specifies the maximum number of compute nodes when enabling autoscaling.
 
 |--min-replicas
-|Specifies the minimum number of compute nodes when enabling autoscaling. Default: `2`
+|Specifies the minimum number of compute nodes when enabling autoscaling.
 
 |--replicas
-|Required: The number (integer) of machines for this machine pool.
+|The number (integer) of machines for this machine pool.
 |===
 
 .Optional arguments inherited from parent commands
@@ -197,10 +197,10 @@ Set 4 replicas on a machine pool named `mp1` on a cluster named `mycluster`.
 
 [source,terminal]
 ----
-$ rosa edit machinepool --replicas=4 --cluster=mycluster --name=mp1
+$ rosa edit machinepool --cluster=mycluster mp1 --replicas=4
 ----
 
-Enable autoscaling on a machine pool named `mp1` with autoscaling set to non-default limits.
+Enable autoscaling on a machine pool named `mp1` on a cluster named `mycluster`.
 
 [source,terminal]
 ----


### PR DESCRIPTION
Add procedure to configure autoscaling nodes on a cluster using the `rosa` CLI. This goes in the main doc set as it is written as a tutorial.

JIRA: https://issues.redhat.com/browse/OSDOCS-1701